### PR TITLE
Adding success/failure handler

### DIFF
--- a/.github/workflows/check_networks.yml
+++ b/.github/workflows/check_networks.yml
@@ -129,6 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: report
     if: always() && (needs.test.result == 'failure')
+    env:
+      GITHUB_WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Report
         uses: appleboy/telegram-action@master
@@ -138,4 +140,8 @@ jobs:
           message: |
             Network tests failed, lets check:
 
-            https://nova-wallet.github.io/test-runner/${{github.run_number}}
+            Failed run:
+            ${{ env.GITHUB_WORKFLOW_URL }}
+
+            Report:
+            https://nova-wallet.github.io/test-runner/${{ github.run_number }}

--- a/.github/workflows/check_networks.yml
+++ b/.github/workflows/check_networks.yml
@@ -145,4 +145,3 @@ jobs:
 
             Report:
             https://nova-wallet.github.io/test-runner/${{ github.run_number }}
-

--- a/.github/workflows/check_networks.yml
+++ b/.github/workflows/check_networks.yml
@@ -145,3 +145,4 @@ jobs:
 
             Report:
             https://nova-wallet.github.io/test-runner/${{ github.run_number }}
+

--- a/.github/workflows/networks_test.sh
+++ b/.github/workflows/networks_test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 adb devices
-# adb logcat -c
-# adb logcat &
 
 # Install debug app
 adb -s emulator-5554 install app/androidTest/debug/app-debug-androidTest.apk
@@ -10,10 +8,42 @@ adb -s emulator-5554 install app/androidTest/debug/app-debug-androidTest.apk
 adb -s emulator-5554 install app/instrumentialTest/app-instrumentialTest.apk
 
 # Run tests
-adb shell am instrument -w -m -e debug false -e class 'io.novafoundation.nova.balances.BalancesIntegrationTest' io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner
-EXIT_STATUS=$?
+adb logcat -c &&
+python - <<END
+import os
+import re
+import subprocess as sp
+import sys
+import threading
+import time
+done = False
+def update():
+  # prevent CI from killing the process for inactivity
+  while not done:
+    time.sleep(5)
+    print ("Running...")
+t = threading.Thread(target=update)
+t.dameon = True
+t.start()
+def run():
+  os.system('adb wait-for-device')
+  p = sp.Popen('adb shell am instrument -w -m -e debug false -e class "io.novafoundation.nova.balances.BalancesIntegrationTest" io.novafoundation.nova.debug.test/io.qameta.allure.android.runners.AllureAndroidJUnitRunner',
+               shell=True, stdout=sp.PIPE, stderr=sp.PIPE, stdin=sp.PIPE)
+  return p.communicate()
+success = re.compile(r'OK \(\d+ tests\)')
+stdout, stderr = run()
+done = True
+print (stderr)
+print (stdout)
+if success.search(stderr + stdout):
+  sys.exit(0)
+else:
+  sys.exit(1) # make sure we fail if the tests fail
+END
+EXIT_CODE=$?
+adb logcat -d '*:E'
 
 # Export results
 adb exec-out run-as io.novafoundation.nova.debug sh -c 'cd /data/data/io.novafoundation.nova.debug/files && tar cf - allure-results' > allure-results.tar
 
-exit $EXIT_STATUS
+exit $EXIT_CODE


### PR DESCRIPTION
Found the problem with running test via adb, that it doesn't return failing exit code if tests was failed. The PR is fixed that behaviour by adding python script for log parsing.